### PR TITLE
Add support for `updatedAfterDate` parameter when retrieving time entries from the API

### DIFF
--- a/src/Rossedman/Teamwork/Time.php
+++ b/src/Rossedman/Teamwork/Time.php
@@ -32,6 +32,11 @@ class Time extends AbstractObject {
      */
     public function allRaw($args = null)
     {
+        $this->areArgumentsValid($args, [
+            'page',
+            'updatedAfterDate'
+        ]);
+        
         return $this->client->get($this->endpoint, $args)->rawResponse();
     }
 }

--- a/src/Rossedman/Teamwork/Time.php
+++ b/src/Rossedman/Teamwork/Time.php
@@ -17,7 +17,10 @@ class Time extends AbstractObject {
      */
     public function all($args = null)
     {
-        $this->areArgumentsValid($args, ['page']);
+        $this->areArgumentsValid($args, [
+            'page',
+            'updatedAfterDate'
+        ]);
 
         return $this->client->get($this->endpoint, $args)->response();
     }

--- a/src/Rossedman/Teamwork/Time.php
+++ b/src/Rossedman/Teamwork/Time.php
@@ -30,8 +30,8 @@ class Time extends AbstractObject {
      *
      * @return mixed
      */
-    public function allRaw()
+    public function allRaw($args = null)
     {
-        return $this->client->get($this->endpoint)->rawResponse();
+        return $this->client->get($this->endpoint, $args)->rawResponse();
     }
 }


### PR DESCRIPTION
Exactly as it says on the tin.

When retrieving time entries, the only parameter we were allowing was the `page` parameter (makes sense, as that's all we were using).

The dashboard code has now been updated to use `updatedAfterDate` as well; but that means we need the API client to also support it, which is what this PR allows for.

One other tweak I've made is to support passing arguments to the `allRaw` method as well, but that just uses exactly the same code as in the `all` method.
